### PR TITLE
docs: Rename repo `omop-data-catalogue` -> `omopcat`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
           - markdown
           - bsicons
           - CDMConnector
+          - RPostgres
       # codemeta must be above use-tidy-description when both are used
       # -   id: codemeta-description-updated
       - id: use-tidy-description

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,5 +57,5 @@ RoxygenNote: 7.3.2
 Config/testthat/edition: 3
 Language: en-US
 Roxygen: list(markdown = TRUE)
-URL: https://github.com/SAFEHR-data/omop-data-catalogue
-BugReports: https://github.com/SAFEHR-data/omop-data-catalogue/issues
+URL: https://github.com/SAFEHR-data/omopcat
+BugReports: https://github.com/SAFEHR-data/omopcat/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,7 @@ This version adds support for OMOP bundles. The app name also changed from `caly
 * Refactored the plots module (@milanmlft, #77)
 * Set default ggplot2 theme with larger font size (@milanmlft, #82)
 
-**Full Changelog**: https://github.com/SAFEHR-data/omop-data-catalogue/compare/v0.1.0...v0.2.0
+**Full Changelog**: https://github.com/SAFEHR-data/omopcat/compare/v0.1.0...v0.2.0
 
 # omopcat 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <!-- badges: start -->
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![R-CMD-check](https://github.com/SAFEHR-data/omop-data-catalogue/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/SAFEHR-data/omop-data-catalogue/actions/workflows/R-CMD-check.yaml)
-[![codecov](https://codecov.io/gh/SAFEHR-data/omop-data-catalogue/graph/badge.svg?token=51UZPgLZMZ)](https://codecov.io/gh/SAFEHR-data/omop-data-catalogue)
+[![R-CMD-check](https://github.com/SAFEHR-data/omopcat/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/SAFEHR-data/omopcat/actions/workflows/R-CMD-check.yaml)
+[![codecov](https://codecov.io/gh/SAFEHR-data/omopcat/graph/badge.svg?token=51UZPgLZMZ)](https://codecov.io/gh/SAFEHR-data/omopcat)
 <!-- badges: end -->
 
 The `omopcat` web app provides an interactive dashboard to display a catalogue of available OMOP data. It enables
@@ -15,7 +15,7 @@ and subsequently export a selection of concepts of interest.
 1. [Installation](#installation)
 1. [Usage](#usage)
 1. [Deployment](#deploying-with-docker)
-1. [Developer instructions](https://github.com/SAFEHR-data/omop-data-catalogue/wiki/)
+1. [Developer instructions](https://github.com/SAFEHR-data/omopcat/wiki/)
 
 ## Installation
 
@@ -25,7 +25,7 @@ You can install the development version of omopcat from within R like so:
 install.packages("remotes")
 usethis::create_github_token()
 credentials::set_github_pat()
-remotes::install_github("SAFEHR-data/omop-data-catalogue")
+remotes::install_github("SAFEHR-data/omopcat")
 ```
 
 You will need to copy the PAT from the web page that `usethis::create_github_token`
@@ -41,7 +41,7 @@ run_app()
 ```
 
 By default, this will run the app in `dev` mode and use a small dummy data set to host the app 
-([see the wiki for more details](https://github.com/SAFEHR-data/omop-data-catalogue/wiki/Data)).
+([see the wiki for more details](https://github.com/SAFEHR-data/omopcat/wiki/Data)).
 
 To run the app in production mode, set the `GOLEM_CONFIG_ACTIVE` environment variable to `production`.
 From within R this can be done by

--- a/inst/app/www/help_tab.md
+++ b/inst/app/www/help_tab.md
@@ -36,7 +36,7 @@ omopcat has a pre-processing step that summarises an OMOP extraction by calculat
 
 #### Contact
 
-https://github.com/SAFEHR-data/omop-data-catalogue
+https://github.com/SAFEHR-data/omopcat
 
 omopcat is made by the SAFEHR-data development team at UCLH and UCL supported by the [UCLH
 Biomedical Research Centre](https://www.uclhospitals.brc.nihr.ac.uk/).

--- a/man/omopcat-package.Rd
+++ b/man/omopcat-package.Rd
@@ -11,8 +11,8 @@ A Shiny app to display an OMOP data catalogue in an interactive dashboard. Enabl
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/SAFEHR-data/omop-data-catalogue}
-  \item Report bugs at \url{https://github.com/SAFEHR-data/omop-data-catalogue/issues}
+  \item \url{https://github.com/SAFEHR-data/omopcat}
+  \item Report bugs at \url{https://github.com/SAFEHR-data/omopcat/issues}
 }
 
 }


### PR DESCRIPTION
Now that we've settled on a name, should make the repo name consistent with the package name.