### PR TITLE
fix(app): keep concepts table at minimum height

### DIFF
--- a/app/R/app_ui.R
+++ b/app/R/app_ui.R
@@ -11,6 +11,7 @@ app_ui <- function(request) {
 
     # The UI logic
     page_navbar(
+      fillable = FALSE,
       title = .app_title(),
       sidebar = sidebar(
         title = "Filtering options",

--- a/app/R/mod_datatable.R
+++ b/app/R/mod_datatable.R
@@ -25,7 +25,8 @@ mod_datatable_ui <- function(id) {
           "Clear selected rows"
         )
       ),
-      DT::DTOutput(ns("datatable"))
+      DT::DTOutput(ns("datatable")),
+      min_height = 650
     )
   )
 }


### PR DESCRIPTION
Prioritise keeping table size consistent over trying to fit everything in one page.
Fixes #112.