### PR TITLE
Removed auto-selection of Row 1 of data table on concepts tab 

### DIFF
--- a/app/R/mod_datatable.R
+++ b/app/R/mod_datatable.R
@@ -93,7 +93,7 @@ mod_datatable_server <- function(id, selected_dates, bundle_concepts) {
         "Vocabulary ID" = "vocabulary_id",
         "Concept Class ID" = "concept_class_id"
       ),
-      selection = list(mode = "multiple", selected = 1, target = "row")
+      selection = list(mode = "multiple", target = "row")
     )
 
     ## Automatically select rows in datatable when a bundle is selected


### PR DESCRIPTION
Fixes #119 

Removed the default selected row 1 in the dateable on the Concepts tab. 

Image from branch run_app() showing the top row is no longer blue and selected. 

![image](https://github.com/user-attachments/assets/6761da00-4b9a-4813-9ab7-54076111a853)
