### PR TITLE
fix: Keep rows selected when date range changes

### DIFF
--- a/app/.Rprofile
+++ b/app/.Rprofile
@@ -1,6 +1,5 @@
 if (interactive()) {
   suppressMessages(require("devtools"))
-  suppressMessages(require("golem"))
 
   # warn about partial matching
   options(

--- a/app/NEWS.md
+++ b/app/NEWS.md
@@ -1,5 +1,12 @@
 # omopcat (development version)
 
+* Keep the concepts table at a minimum height (@milanmlft #114)
+* Use better low-frequency replacement values (@milanmlft #115)
+* Improved docker build speed and caching (@stefpiatek #118)
+* Removed auto-selection of first row in the concepts table (@DW10 #120)
+* Keep the `value_as_concept_id` column in the summary stats table (@milanmlft #122)
+* Keep rows selected when date range changes (@milanmlft #123)
+
 # omopcat 0.2.2
 
 Refactoring the deployment setup and reorganise the repo (@milanmlft in #108).

--- a/app/R/mod_datatable.R
+++ b/app/R/mod_datatable.R
@@ -82,7 +82,7 @@ mod_datatable_server <- function(id, selected_dates, bundle_concepts) {
       selection = list(mode = "multiple", target = "row")
     )
 
-    datatable_proxy <- DT::dataTableProxy("datatable", session = session, deferUntilFlush = TRUE)
+    datatable_proxy <- DT::dataTableProxy("datatable")
 
     ## Recompute the concepts with counts when the selected dates change
     observeEvent(selected_dates(), {
@@ -94,15 +94,12 @@ mod_datatable_server <- function(id, selected_dates, bundle_concepts) {
       DT::selectRows(datatable_proxy, selected = selected_rows)
     })
 
-    ## Automatically select rows in datatable when a bundle is selected
-    row_indices <- eventReactive(bundle_concepts(), {
-      selected_concept_ids <- bundle_concepts()
-      match(selected_concept_ids, rv$concepts_with_counts$concept_id)
+    ## Update the selected rows when the bundle changes
+    observeEvent(bundle_concepts(), {
+      rows_to_select <- which(rv$concepts_with_counts$concept_id %in% bundle_concepts())
+      DT::selectRows(datatable_proxy, selected = rows_to_select)
     })
 
-    observeEvent(row_indices(), {
-      DT::selectRows(datatable_proxy, selected = row_indices())
-    })
     observeEvent(input$clear_rows, {
       DT::selectRows(datatable_proxy, selected = NULL) # nocov
     })

--- a/app/R/mod_datatable.R
+++ b/app/R/mod_datatable.R
@@ -64,7 +64,8 @@ mod_datatable_server <- function(id, selected_dates, bundle_concepts) {
 
   moduleServer(id, function(input, output, session) {
     rv <- reactiveValues(
-      concepts_with_counts = join_counts_to_concepts(all_concepts, monthly_counts)
+      concepts_with_counts = join_counts_to_concepts(all_concepts, monthly_counts),
+      bundle_concept_rows = NULL # store this in rv so we have access when testing
     )
 
     output$datatable <- DT::renderDT(rv$concepts_with_counts,
@@ -96,8 +97,8 @@ mod_datatable_server <- function(id, selected_dates, bundle_concepts) {
 
     ## Update the selected rows when the bundle changes
     observeEvent(bundle_concepts(), {
-      rows_to_select <- which(rv$concepts_with_counts$concept_id %in% bundle_concepts())
-      DT::selectRows(datatable_proxy, selected = rows_to_select)
+      rv$bundle_concept_rows <- which(rv$concepts_with_counts$concept_id %in% bundle_concepts())
+      DT::selectRows(datatable_proxy, selected = rv$bundle_concept_rows)
     })
 
     observeEvent(input$clear_rows, {

--- a/app/tests/testthat/test-mod_datatable.R
+++ b/app/tests/testthat/test-mod_datatable.R
@@ -29,8 +29,8 @@ test_that("datatable server works", {
       # To check this, we access the reactive object `concepts_with_counts` created within the server
       selected_dates(c("2020-01-01", "2020-12-31"))
       session$flushReact()
-      expect_equal(nrow(concepts_with_counts()), 4)
-      expect_true(all(concepts_with_counts()$total_records > 0))
+      expect_equal(nrow(rv$concepts_with_counts), 4)
+      expect_true(all(rv$concepts_with_counts$total_records > 0))
     }
   )
 })
@@ -45,9 +45,10 @@ test_that("Selected rows are updated when updating `bundle_concepts`", {
     {
       # Not really possible to test the updating of the selected rows, but we can check
       # whether the reactive row_indices get updated correctly as a proxy
-      select_concepts <- concepts_with_counts()$concept_id[c(1, 2)]
+      select_concepts <- rv$concepts_with_counts$concept_id[c(1, 2)]
       bundle_concepts(select_concepts)
-      expect_equal(row_indices(), c(1, 2))
+      session$flushReact()
+      expect_equal(rv$bundle_concept_rows, c(1, 2))
     }
   )
 })


### PR DESCRIPTION
Before when some rows are selected and then the date range gets changed, the selections would disappear. This PR makes sure the row selection is retained by keeping track of the selected concepts and re-selecting them after the data is re-computed upon a date-range change.