### PR TITLE
Disable `return_linter`

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,7 @@
 linters: linters_with_defaults(
     line_length_linter(120),
     object_name_linter(styles = c("snake_case", "symbols", "camelCase")),
-    object_length_linter(NULL)
+    object_length_linter(NULL),
+    return_linter = NULL
   )
 encoding: "UTF-8"


### PR DESCRIPTION
Explicit returns are kinda nice.
Should unblock #135.